### PR TITLE
Fix Linux init flow for fitting_function_box.py

### DIFF
--- a/src/eddington_gui/boxes/fitting_function_box.py
+++ b/src/eddington_gui/boxes/fitting_function_box.py
@@ -43,9 +43,10 @@ class FittingFunctionBox(LineBox):  # pylint: disable=too-many-instance-attribut
         self.polynomial_degree_input = toga.NumberInput(
             min_value=1,
             max_value=5,
-            value=1,
-            on_change=lambda widget: self.set_polynomial_degree(),
+            value=1
         )
+        # This function uses self.polynomial_degree_input, so we attach it after the relevant assignment
+        self.polynomial_degree_input.on_change = lambda widget: self.set_polynomial_degree()
 
         self.update_fitting_function_options()
         self.on_fitting_function_load = on_fitting_function_load


### PR DESCRIPTION
When a toga.NumberInput is created in Linux, it's change function is called immediately. Since our fitting function box is not yet created (specifically, the polynomial_degree_input property is not yet saved) we have a problem.

The fix is to make sure that we attach the on_change function only after the variable is assigned